### PR TITLE
Fix RXCROPMATURITY test in zerothtstep branch

### DIFF
--- a/python/ctsm/crop_calendars/generate_gdds_functions.py
+++ b/python/ctsm/crop_calendars/generate_gdds_functions.py
@@ -217,7 +217,7 @@ def import_and_process_1yr(
     else:
         chunks = None
 
-    # Get h2 file (list)
+    # Get h1 file (list)
     h1_pattern = os.path.join(indir, "*h1.*.nc")
     h1_filelist = glob.glob(h1_pattern)
     if not h1_filelist:

--- a/python/ctsm/crop_calendars/generate_gdds_functions.py
+++ b/python/ctsm/crop_calendars/generate_gdds_functions.py
@@ -45,6 +45,7 @@ def log(logger, string):
 
 
 def error(logger, string):
+    print(string)
     logger.error(string)
     raise RuntimeError(string)
 

--- a/python/ctsm/crop_calendars/generate_gdds_functions.py
+++ b/python/ctsm/crop_calendars/generate_gdds_functions.py
@@ -478,13 +478,14 @@ def import_and_process_1yr(
     log(logger, f"   Importing accumulated GDDs...")
     clm_gdd_var = "GDDACCUM"
     myVars = [clm_gdd_var, "GDDHARV"]
-    pattern = os.path.join(indir, f"*h2.{thisYear-1}-01-01*.nc")
-    h2_files = glob.glob(pattern)
-    if not h2_files:
-        pattern = os.path.join(indir, f"*h2.{thisYear-1}-01-01*.nc.base")
+    patterns = [f"*h2.{thisYear-1}-01-01*.nc", f"*h2.{thisYear-1}-01-01*.nc.base"]
+    for p in patterns:
+        pattern = os.path.join(indir, p)
         h2_files = glob.glob(pattern)
-        if not h2_files:
-            error(logger, f"No files found matching pattern '*h2.{thisYear-1}-01-01*.nc(.base)'")
+        if h2_files:
+            break
+    if not h2_files:
+        error(logger, f"No files found matching patterns: {patterns}")
     h2_ds = utils.import_ds(
         h2_files,
         myVars=myVars,

--- a/python/ctsm/crop_calendars/generate_gdds_functions.py
+++ b/python/ctsm/crop_calendars/generate_gdds_functions.py
@@ -478,7 +478,7 @@ def import_and_process_1yr(
     log(logger, f"   Importing accumulated GDDs...")
     clm_gdd_var = "GDDACCUM"
     myVars = [clm_gdd_var, "GDDHARV"]
-    patterns = [f"*h2.{thisYear-1}-01-01*.nc", f"*h2.{thisYear-1}-01-01*.nc.base"]
+    patterns = [f"*h2.{thisYear-1}-01*.nc", f"*h2.{thisYear-1}-01*.nc.base"]
     for p in patterns:
         pattern = os.path.join(indir, p)
         h2_files = glob.glob(pattern)


### PR DESCRIPTION
### Description of changes
Fixes RXCROPMATURITY system test, which was broken by daily-step file names now having date YYYY-01-02.

### Specific notes

**Contributors other than yourself, if any:** None.

**CTSM Issues Fixed:** None, but see description [here](https://github.com/ESCOMP/CTSM/pull/2084#issuecomment-1789685234).

**Are answers expected to change (and if so in what way)?** No.

**Any User Interface Changes (namelist or namelist defaults changes)?** No.

**Testing performed, if any:** `RXCROPMATURITY_Lm61.f10_f10_mg37.IHistClm51BgcCrop.cheyenne_intel.clm-cropMonthOutput` now works.
